### PR TITLE
add pull request template file for github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Describe your changes
+
+## Issue link
+
+## Checklist before requesting a review
+- [ ] I have performed a self-review of my code
+- [ ] My code is well documented/readable (comments when needed)
+- [ ] All of my unit tests pass
+- [ ] New thorough unit tests were added (if needed)
+- [ ] No linting errors (run pylint) 
+- [ ] Python code is formatted using Black


### PR DESCRIPTION
Adding this file to our .github folder allows github to automagically populate this description field with our template. No more copying and pasting!